### PR TITLE
Fix crashes when server rendering

### DIFF
--- a/src/packages/use-location-state/src/useLocationState/useLocationState.ts
+++ b/src/packages/use-location-state/src/useLocationState/useLocationState.ts
@@ -19,7 +19,7 @@ export default function useLocationState<S>(
 
   // item name gets a generated suffix based on defaultValue type, to make accidental clashes less likely
   ;[itemName] = useState(() => {
-    const suffixObscurer = btoa || ((s: string) => s)
+    const suffixObscurer = typeof btoa !== "undefined" ? btoa : ((s: string) => s)
     const suffix = suffixObscurer(
       Array.isArray(defaultValue) ? 'array' : typeof defaultValue
     ).replace(/=/g, '')


### PR DESCRIPTION
Perhaps this is only a problem with Gatsby, but when building my Gatsby project with this library I hit this error:

```sh
Building static HTML failed for path "/planner/"

See our docs page for more info on this error: https://gatsby.dev/debug-html


  227 |     }
  228 |     itemName = useState(function () {
> 229 |         var suffixObscurer = btoa || (function (s) { return s; });
  230 |         var suffix = suffixObscurer(Array.isArray(defaultValue) ? 'array' : typeof defaultValue).replace(/=/g, '');
  231 |         return itemName + "__" + suffix;
  232 |     })[0];

  WebpackError: ReferenceError: btoa is not defined
  
  - use-location-state.esm.js:229 
    node_modules/use-location-state/dist/use-location-state.esm.js:229:1
  
  - use-location-state.esm.js:228 useLocationState
    node_modules/use-location-state/dist/use-location-state.esm.js:228:24
```

I patched the library and it worked, so I thought I'd submit my fix here!