### PR TITLE
return React 16 support

### DIFF
--- a/src/packages/react-router-use-location-state/package.json
+++ b/src/packages/react-router-use-location-state/package.json
@@ -5,7 +5,7 @@
   "types": "dist/react-router-use-location-state.d.ts",
   "description": "react hook to the browsers location query state",
   "peerDependencies": {
-    "react": "^17.0.2",
+    "react": "^16.8.0 || ^17.0.2",
     "react-router": "^6.0.2"
   },
   "dependencies": {

--- a/src/packages/use-location-state/package.json
+++ b/src/packages/use-location-state/package.json
@@ -5,7 +5,7 @@
   "types": "dist/use-location-state.d.ts",
   "description": "react hook to the browsers location query state",
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^16.8.0 || ^17.0.2"
   },
   "dependencies": {
     "query-state-core": "^3.0.0"


### PR DESCRIPTION
The change from ebe27305cb63d5 might be considered breaking
as before it, React 16 was supported, and after it it is no longer so.

This makes the peerDependency on React more forgiving, staying
compatible with previously supported React 16 versions and keeping
the newly added React 17 support as well.