### PR TITLE
Change router.pathname to router.asPath for dynamic paths

### DIFF
--- a/src/packages/use-location-state/src/next.ts
+++ b/src/packages/use-location-state/src/next.ts
@@ -38,7 +38,7 @@ const useNextRouterQueryStringInterface = (): QueryStringInterface => {
         Promise.resolve().then(resolve)
       })
         .then(() => {
-          router[method](router.asPath + '?' + newQueryString)
+          router[method](router.asPath.split("?")[1] + '?' + newQueryString)
         })
         .catch(() => {
           // Ignore, the update will be batched and merged

--- a/src/packages/use-location-state/src/next.ts
+++ b/src/packages/use-location-state/src/next.ts
@@ -38,7 +38,7 @@ const useNextRouterQueryStringInterface = (): QueryStringInterface => {
         Promise.resolve().then(resolve)
       })
         .then(() => {
-          router[method](router.pathname + '?' + newQueryString)
+          router[method](router.asPath + '?' + newQueryString)
         })
         .catch(() => {
           // Ignore, the update will be batched and merged


### PR DESCRIPTION
In nextjs, when you have a path such as /posts/1/edit, after you edit the value that was bound with useQueryState, it would turn to something like /posts/[id]/edit?key=val.

This is because router.pathname would be /posts/[id]/edit instead of posts/1/edit.

I fixed this, and tested the on our app which worked.

PS: It was quite hard to get the everything bootstrapped to publish the packages, can we get a simple CONTRIBUTING.md on how to bootstrap the dev machine from a base npm/yarn installed environment